### PR TITLE
GM-35 Dockerfile 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-alpine
+VOLUME /tmp
+COPY build/libs/servicediscovery-0.0.1-SNAPSHOT.jar api.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar",  "api.jar"]


### PR DESCRIPTION
CICD에 사용할 도커 파일 생성
자바 17 버전을 사용했음.